### PR TITLE
Update ItemManaRing to also use durability bar instead of damage

### DIFF
--- a/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemManaRing.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemManaRing.java
@@ -51,12 +51,6 @@ public class ItemManaRing extends ItemBauble implements IManaItem, IManaTooltipD
 	}
 
 	@Override
-	public int getDamage(ItemStack stack) {
-		float mana = getMana(stack);
-		return 1000 - (int) (mana / getMaxMana(stack) * 1000);
-	}
-
-	@Override
 	public int getEntityLifespan(ItemStack itemStack, World world) {
 		return Integer.MAX_VALUE;
 	}
@@ -78,7 +72,6 @@ public class ItemManaRing extends ItemBauble implements IManaItem, IManaTooltipD
 	@Override
 	public void addMana(ItemStack stack, int mana) {
 		setMana(stack, Math.min(getMana(stack) + mana, getMaxMana(stack)));
-		stack.setItemDamage(getDamage(stack));
 	}
 
 	@Override
@@ -109,6 +102,18 @@ public class ItemManaRing extends ItemBauble implements IManaItem, IManaTooltipD
 	@Override
 	public float getManaFractionForDisplay(ItemStack stack) {
 		return (float) getMana(stack) / (float) getMaxMana(stack);
+	}
+
+	@Override
+	public boolean showDurabilityBar(ItemStack stack) {
+		// For mana rings, always show the durability bar.
+		return true;
+	}
+
+	@Override
+	public double getDurabilityForDisplay(ItemStack stack) {
+		// As in ItemManaTablet, forge seems to have their durability swapped, hence the 1.0 -
+		return 1.0 - getManaFractionForDisplay(stack);
 	}
 
 }


### PR DESCRIPTION
This is not a particularly impressive PR, but it also updates the Mana Ring / Greater Mana Ring to use the durability bar functions instead of item damage. Any other items which need the same/similar changes can be squashed into this PR as well.

Of course, just make issues for anything else which you'd like some help with, or just make the changes yourself if it suits your fancy.

Evidence of still-workingness:

![2016-02-27_23 26 27](https://cloud.githubusercontent.com/assets/616490/13377674/9196e334-ddaa-11e5-8fd3-aea0f11b371c.png)
![2016-02-27_23 27 13](https://cloud.githubusercontent.com/assets/616490/13377676/919743c4-ddaa-11e5-8bc2-431e8f9e58e9.png)
![2016-02-27_23 29 54](https://cloud.githubusercontent.com/assets/616490/13377675/91972bdc-ddaa-11e5-93af-c850fd8a4d3d.png)

(I found a temple right by my spawn - wierd).
