### PR TITLE
Make Kekimurus more cautious about cake slices

### DIFF
--- a/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileKekimurus.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileKekimurus.java
@@ -38,7 +38,7 @@ public class SubTileKekimurus extends SubTileGenerating {
 						Block block = state.getBlock();
 						if(block instanceof BlockCake) {
 							int nextSlicesEaten = state.getValue(BlockCake.BITES) + 1;
-							if(nextSlicesEaten == 6)
+							if(nextSlicesEaten >= 6)
 								supertile.getWorld().setBlockToAir(pos);
 							else supertile.getWorld().setBlockState(pos, state.withProperty(BlockCake.BITES, nextSlicesEaten), 1 | 2);
 


### PR DESCRIPTION
On our server, we got this bizarre error:

`
java.lang.IllegalArgumentException: Cannot set property PropertyInteger{name=bites, clazz=class java.lang.Integer, values=[0, 1, 2, 3, 4, 5, 6]} to 7 on block minecraft:cake, it is not an allowed value
`

I can't see how we ended up with a cake with `bites==6`, but we did, and it made all of our kekis turn into the bugged "Botania Flower". (I punched one of the cakes after the server came back up, and it disappeared, so we did have a bugged cake for some reason...)

Hopefully this one-character change will stop this from happening in the future.
