### PR TITLE
Catalysts can accept any catalyst BlockState.

### DIFF
--- a/src/main/java/vazkii/botania/api/BotaniaAPI.java
+++ b/src/main/java/vazkii/botania/api/BotaniaAPI.java
@@ -473,7 +473,7 @@ public final class BotaniaAPI {
 	 */
 	public static RecipeManaInfusion registerManaAlchemyRecipe(ItemStack output, Object input, int mana) {
 		RecipeManaInfusion recipe = registerManaInfusionRecipe(output, input, mana);
-		recipe.setAlchemy(true);
+		recipe.setCatalyst(RecipeManaInfusion.alchemyState);
 		return recipe;
 	}
 
@@ -484,7 +484,7 @@ public final class BotaniaAPI {
 	 */
 	public static RecipeManaInfusion registerManaConjurationRecipe(ItemStack output, Object input, int mana) {
 		RecipeManaInfusion recipe = registerManaInfusionRecipe(output, input, mana);
-		recipe.setConjuration(true);
+		recipe.setCatalyst(RecipeManaInfusion.conjurationState);
 		return recipe;
 	}
 
@@ -503,7 +503,7 @@ public final class BotaniaAPI {
 	/**
 	 * Registers a Brew Recipe (for the Botanical Brewery).
 	 * @param brew The brew in to be set in this recipe.
-	 * @inputs The items used in the recipe, no more than 6.
+	 * @param inputs The items used in the recipe, no more than 6.
 	 */
 	public static RecipeBrew registerBrewRecipe(Brew brew, Object... inputs) {
 		Preconditions.checkArgument(inputs.length <= 6);

--- a/src/main/java/vazkii/botania/api/package-info.java
+++ b/src/main/java/vazkii/botania/api/package-info.java
@@ -1,4 +1,4 @@
-@API(owner = "Botania", apiVersion = "77", provides = "BotaniaAPI")
+@API(owner = "Botania", apiVersion = "78", provides = "BotaniaAPI")
 package vazkii.botania.api;
 import net.minecraftforge.fml.common.API;
 

--- a/src/main/java/vazkii/botania/api/recipe/RecipeManaInfusion.java
+++ b/src/main/java/vazkii/botania/api/recipe/RecipeManaInfusion.java
@@ -10,9 +10,11 @@
  */
 package vazkii.botania.api.recipe;
 
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 public class RecipeManaInfusion {
@@ -20,8 +22,10 @@ public class RecipeManaInfusion {
 	private final ItemStack output;
 	private final Object input;
 	private final int mana;
-	boolean isAlchemy = false;
-	boolean isConjuration = false;
+	private @Nullable IBlockState catalystState;
+
+	public static IBlockState alchemyState;
+	public static IBlockState conjurationState;
 
 	public RecipeManaInfusion(ItemStack output, Object input, int mana) {
 		this.output = output;
@@ -54,20 +58,12 @@ public class RecipeManaInfusion {
 		return false;
 	}
 
-	public void setAlchemy(boolean alchemy) {
-		isAlchemy = alchemy;
+	public IBlockState getCatalyst() {
+		return catalystState;
 	}
 
-	public boolean isAlchemy() {
-		return isAlchemy;
-	}
-
-	public void setConjuration(boolean conjuration) {
-		isConjuration = conjuration;
-	}
-
-	public boolean isConjuration() {
-		return isConjuration;
+	public void setCatalyst(IBlockState catalyst) {
+		catalystState = catalyst;
 	}
 
 	public Object getInput() {
@@ -80,6 +76,46 @@ public class RecipeManaInfusion {
 
 	public int getManaToConsume() {
 		return mana;
+	}
+
+
+
+	/**
+	 * @deprecated Use {@link RecipeManaInfusion#setCatalyst(IBlockState)} instead
+	 */
+	@Deprecated
+	public void setAlchemy(boolean alchemy) {
+		if (alchemy)
+			catalystState = alchemyState;
+		else
+			catalystState = null;
+	}
+
+	/**
+	 * @deprecated Use {@link RecipeManaInfusion#getCatalyst()} instead
+	 */
+	@Deprecated
+	public boolean isAlchemy() {
+		return catalystState != null && catalystState.equals(alchemyState);
+	}
+
+	/**
+	 * @deprecated Use {@link RecipeManaInfusion#setCatalyst(IBlockState)} instead
+	 */
+	@Deprecated
+	public void setConjuration(boolean conjuration) {
+		if (conjuration)
+			catalystState = conjurationState;
+		else
+			catalystState = null;
+	}
+
+	/**
+	 * @deprecated Use {@link RecipeManaInfusion#getCatalyst()} instead
+	 */
+	@Deprecated
+	public boolean isConjuration() {
+		return catalystState != null && catalystState.equals(conjurationState);
 	}
 }
 

--- a/src/main/java/vazkii/botania/api/recipe/RecipeMiniFlower.java
+++ b/src/main/java/vazkii/botania/api/recipe/RecipeMiniFlower.java
@@ -17,7 +17,7 @@ public class RecipeMiniFlower extends RecipeManaInfusion {
 
 	public RecipeMiniFlower(String flower, String mini, int mana) {
 		super(BotaniaAPI.internalHandler.getSubTileAsStack(flower), BotaniaAPI.internalHandler.getSubTileAsStack(mini), mana);
-		setAlchemy(true);
+		setCatalyst(RecipeManaInfusion.alchemyState);
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/client/core/handler/HUDHandler.java
+++ b/src/main/java/vazkii/botania/client/core/handler/HUDHandler.java
@@ -278,7 +278,7 @@ public final class HUDHandler {
 		profiler.startSection("poolRecipe");
 		for(RecipeManaInfusion recipe : BotaniaAPI.manaInfusionRecipes) {
 			if(recipe.matches(stack)) {
-				if((!recipe.isAlchemy() || tile.alchemy) && (!recipe.isConjuration() || tile.conjuration)) {
+				if(recipe.getCatalyst() == null || tile.getWorld().getBlockState(tile.getPos().down()).equals(recipe.getCatalyst())) {
 					int x = res.getScaledWidth() / 2 - 11;
 					int y = res.getScaledHeight() / 2 + 10;
 

--- a/src/main/java/vazkii/botania/client/core/handler/MiscellaneousIcons.java
+++ b/src/main/java/vazkii/botania/client/core/handler/MiscellaneousIcons.java
@@ -50,6 +50,7 @@ public class MiscellaneousIcons {
         lightRelayWorldIcon,
         lightRelayWorldIconRed,
         alchemyCatalystOverlay,
+        conjurationCatalystOverlay,
         enchanterOverlay,
         manaVoidOverlay,
         manaWater,
@@ -105,6 +106,7 @@ public class MiscellaneousIcons {
         lightRelayWorldIcon = IconHelper.forName(evt.getMap(), "lightRelay1", "blocks");
         lightRelayWorldIconRed = IconHelper.forName(evt.getMap(), "lightRelay3", "blocks");
         alchemyCatalystOverlay = IconHelper.forName(evt.getMap(), "alchemyCatalyst3", "blocks");
+        conjurationCatalystOverlay = IconHelper.forName(evt.getMap(), "conjurationCatalyst3", "blocks");
         enchanterOverlay = IconHelper.forName(evt.getMap(), "enchanterOverlay", "blocks");
         manaVoidOverlay = IconHelper.forName(evt.getMap(), "manaVoid1", "blocks");
         manaWater = IconHelper.forName(evt.getMap(), "manaWater", "blocks");

--- a/src/main/java/vazkii/botania/client/integration/jei/manapool/ManaPoolRecipeWrapper.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/manapool/ManaPoolRecipeWrapper.java
@@ -10,8 +10,10 @@ package vazkii.botania.client.integration.jei.manapool;
 
 import com.google.common.collect.ImmutableList;
 import mezz.jei.api.recipe.IRecipeWrapper;
+import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.oredict.OreDictionary;
@@ -31,7 +33,7 @@ public class ManaPoolRecipeWrapper implements IRecipeWrapper {
 	private final int mana;
 
 	public ManaPoolRecipeWrapper(RecipeManaInfusion recipe) {
-		ImmutableList.Builder builder = ImmutableList.builder();
+		ImmutableList.Builder<Object> builder = ImmutableList.builder();
 
 		if(recipe.getInput() instanceof ItemStack) {
 			builder.add(recipe.getInput());
@@ -39,10 +41,11 @@ public class ManaPoolRecipeWrapper implements IRecipeWrapper {
 			builder.add(OreDictionary.getOres(((String) recipe.getInput())));
 		}
 
-		if(recipe.isAlchemy()) {
-			builder.add(new ItemStack(ModBlocks.alchemyCatalyst));
-		} else if(recipe.isConjuration()) {
-			builder.add(new ItemStack(ModBlocks.conjurationCatalyst));
+		if(recipe.getCatalyst() != null) {
+			Block block = recipe.getCatalyst().getBlock();
+			if (Item.getItemFromBlock(block) != null) {
+				builder.add(new ItemStack(block, 1, block.getMetaFromState(recipe.getCatalyst())));
+			}
 		}
 
 		input = builder.build();

--- a/src/main/java/vazkii/botania/common/block/ModBlocks.java
+++ b/src/main/java/vazkii/botania/common/block/ModBlocks.java
@@ -18,6 +18,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.oredict.OreDictionary;
 import vazkii.botania.api.BotaniaAPI;
+import vazkii.botania.api.recipe.RecipeManaInfusion;
 import vazkii.botania.api.state.BotaniaStateProps;
 import vazkii.botania.api.subtile.SubTileEntity;
 import vazkii.botania.client.lib.LibResources;
@@ -408,6 +409,9 @@ public final class ModBlocks {
 
 		BotaniaAPI.registerPaintableBlock(unstableBlock, BotaniaStateProps.COLOR);
 		BotaniaAPI.registerPaintableBlock(manaBeacon, BotaniaStateProps.COLOR);
+
+		RecipeManaInfusion.alchemyState = alchemyCatalyst.getDefaultState();
+		RecipeManaInfusion.conjurationState = conjurationCatalyst.getDefaultState();
 
 		initTileEntities();
 	}

--- a/src/main/java/vazkii/botania/common/block/mana/BlockConjurationCatalyst.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockConjurationCatalyst.java
@@ -10,11 +10,15 @@
  */
 package vazkii.botania.common.block.mana;
 
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import vazkii.botania.api.lexicon.LexiconEntry;
+import vazkii.botania.client.core.handler.MiscellaneousIcons;
 import vazkii.botania.common.lexicon.LexiconData;
 import vazkii.botania.common.lib.LibBlockNames;
 
@@ -27,5 +31,11 @@ public class BlockConjurationCatalyst extends BlockAlchemyCatalyst {
 	@Override
 	public LexiconEntry getEntry(World world, BlockPos pos, EntityPlayer player, ItemStack lexicon) {
 		return LexiconData.conjurationCatalyst;
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public TextureAtlasSprite getIcon(World world, BlockPos pos) {
+		return MiscellaneousIcons.INSTANCE.conjurationCatalystOverlay;
 	}
 }

--- a/src/main/java/vazkii/botania/common/block/tile/mana/TilePool.java
+++ b/src/main/java/vazkii/botania/common/block/tile/mana/TilePool.java
@@ -84,9 +84,6 @@ public class TilePool extends TileMod implements IManaPool, IDyablePool, IKeyLoc
 	private static final String TAG_OUTPUT_KEY = "outputKey";
 
 	boolean outputting = false;
-	public boolean alchemy = false;
-	public boolean conjuration = false;
-	boolean catalystsRegistered = false;
 
 	public EnumDyeColor color = EnumDyeColor.WHITE;
 	int mana;
@@ -160,11 +157,11 @@ public class TilePool extends TileMod implements IManaPool, IDyablePool, IKeyLoc
 			age = ((int) MethodHandles.itemAge_getter.invokeExact(item));
 		} catch (Throwable throwable) { return false; }
 
-		if(age > 100 && age < 130 || !catalystsRegistered)
+		if(age > 100 && age < 130)
 			return false;
 
 		for(RecipeManaInfusion recipe : BotaniaAPI.manaInfusionRecipes) {
-			if(recipe.matches(stack) && (!recipe.isAlchemy() || alchemy) && (!recipe.isConjuration() || conjuration)) {
+			if(recipe.matches(stack) && (recipe.getCatalyst() == null || worldObj.getBlockState(pos.down()).equals(recipe.getCatalyst()))) {
 				int mana = recipe.getManaToConsume();
 				if(getCurrentMana() >= mana) {
 					recieveMana(-mana);
@@ -231,10 +228,6 @@ public class TilePool extends TileMod implements IManaPool, IDyablePool, IKeyLoc
 			VanillaPacketDispatcher.dispatchTEToNearbyPlayers(this);
 			sendPacket = false;
 		}
-
-		alchemy = worldObj.getBlockState(pos.down()).getBlock() == ModBlocks.alchemyCatalyst;
-		conjuration = worldObj.getBlockState(pos.down()).getBlock() == ModBlocks.conjurationCatalyst;
-		catalystsRegistered = true;
 
 		List<EntityItem> items = worldObj.getEntitiesWithinAABB(EntityItem.class, new AxisAlignedBB(pos, pos.add(1, 1, 1)));
 		for(EntityItem item : items) {

--- a/src/main/java/vazkii/botania/common/lexicon/page/PageManaInfusionRecipe.java
+++ b/src/main/java/vazkii/botania/common/lexicon/page/PageManaInfusionRecipe.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiScreen;
@@ -83,10 +84,12 @@ public class PageManaInfusionRecipe extends PageRecipe {
 
 		renderItemAtGridPos(gui, 3, 1, recipe.getOutput(), false);
 
-		if(recipe.isAlchemy())
-			renderItemAtGridPos(gui, 1, 2, new ItemStack(ModBlocks.alchemyCatalyst), false);
-		else if(recipe.isConjuration())
-			renderItemAtGridPos(gui, 1, 2, new ItemStack(ModBlocks.conjurationCatalyst), false);
+		if(recipe.getCatalyst() != null) {
+			Block block = recipe.getCatalyst().getBlock();
+			if (Item.getItemFromBlock(block) != null) {
+				renderItemAtGridPos(gui, 1, 2, new ItemStack(block, 1, block.getMetaFromState(recipe.getCatalyst())), false);
+			}
+		}
 
 		GlStateManager.enableBlend();
 		GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);


### PR DESCRIPTION
This constitutes a major, but not breaking, API update. All catalyst
methods previously in RecipeManaInfusion have been deprecated.
