### PR TITLE
Iron out some kinks in the Bauble Box and Flower Pouch

### DIFF
--- a/src/main/java/vazkii/botania/client/gui/box/ContainerBaubleBox.java
+++ b/src/main/java/vazkii/botania/client/gui/box/ContainerBaubleBox.java
@@ -99,7 +99,6 @@ public class ContainerBaubleBox extends Container {
 			ItemStack itemstack1 = slot.getStack();
 			itemstack = itemstack1.copy();
 
-			System.out.println(p_82846_2_ + " " + itemstack);
 			if(p_82846_2_ < 28) {
 				if(!mergeItemStack(itemstack1, 28, 64, true))
 					return null;

--- a/src/main/java/vazkii/botania/client/gui/box/InventoryBaubleBox.java
+++ b/src/main/java/vazkii/botania/client/gui/box/InventoryBaubleBox.java
@@ -24,7 +24,7 @@ import java.util.Arrays;
 
 public class InventoryBaubleBox implements IInventory {
 
-	private static final ItemStack[] FALLBACK_INVENTORY = new ItemStack[16];
+	private static final ItemStack[] FALLBACK_INVENTORY = new ItemStack[36];
 
 	final EntityPlayer player;
 	final int slot;
@@ -80,7 +80,7 @@ public class InventoryBaubleBox implements IInventory {
 
 	@Override
 	public int getSizeInventory() {
-		return 16;
+		return 36;
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/client/gui/box/InventoryBaubleBox.java
+++ b/src/main/java/vazkii/botania/client/gui/box/InventoryBaubleBox.java
@@ -24,7 +24,7 @@ import java.util.Arrays;
 
 public class InventoryBaubleBox implements IInventory {
 
-	private static final ItemStack[] FALLBACK_INVENTORY = new ItemStack[36];
+	private static final ItemStack[] FALLBACK_INVENTORY = new ItemStack[24];
 
 	final EntityPlayer player;
 	final int slot;
@@ -80,7 +80,7 @@ public class InventoryBaubleBox implements IInventory {
 
 	@Override
 	public int getSizeInventory() {
-		return 36;
+		return 24;
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/item/ItemBaubleBox.java
+++ b/src/main/java/vazkii/botania/common/item/ItemBaubleBox.java
@@ -38,6 +38,9 @@ public class ItemBaubleBox extends ItemMod {
 	@Nonnull
 	@Override
 	public ActionResult<ItemStack> onItemRightClick(@Nonnull ItemStack stack, World world, EntityPlayer player, EnumHand hand) {
+		if(hand == EnumHand.OFF_HAND) {
+			return ActionResult.newResult(EnumActionResult.PASS, stack);
+		}
 		player.openGui(Botania.instance, LibGuiIDs.BAUBLE_BOX, world, 0, 0, 0);
 		return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
 	}

--- a/src/main/java/vazkii/botania/common/item/ItemBaubleBox.java
+++ b/src/main/java/vazkii/botania/common/item/ItemBaubleBox.java
@@ -48,7 +48,7 @@ public class ItemBaubleBox extends ItemMod {
 
 	public static ItemStack[] loadStacks(ItemStack stack) {
 		NBTTagList var2 = ItemNBTHelper.getList(stack, TAG_ITEMS, 10, false);
-		ItemStack[] inventorySlots = new ItemStack[36];
+		ItemStack[] inventorySlots = new ItemStack[24];
 		for(int var3 = 0; var3 < var2.tagCount(); ++var3) {
 			NBTTagCompound var4 = var2.getCompoundTagAt(var3);
 			byte var5 = var4.getByte(TAG_SLOT);

--- a/src/main/java/vazkii/botania/common/item/ItemFlowerBag.java
+++ b/src/main/java/vazkii/botania/common/item/ItemFlowerBag.java
@@ -107,6 +107,9 @@ public class ItemFlowerBag extends ItemMod {
 	@Nonnull
 	@Override
 	public ActionResult<ItemStack> onItemRightClick(@Nonnull ItemStack stack, World world, EntityPlayer player, EnumHand hand) {
+		if(hand == EnumHand.OFF_HAND) {
+			return ActionResult.newResult(EnumActionResult.PASS, stack);
+		}
 		player.openGui(Botania.instance, LibGuiIDs.FLOWER_BAG, world, 0, 0, 0);
 		return ActionResult.newResult(EnumActionResult.SUCCESS, stack);
 	}


### PR DESCRIPTION
- Remove a debug `println()` in ContainerBaubleBox.
- Resize `InventoryBaubleBox.FALLBACK_INVENTORY` and change
  `getSizeInventory()` to 36 instead of 16.
- Disallow opening the Bauble Case or the Flower Pouch from
  the offhand.

Fixes #297
