### PR TITLE
Make Falling Lit Redstone Ore and Lamps drop their blocks

### DIFF
--- a/src/main/java/vazkii/botania/common/item/lens/LensWeight.java
+++ b/src/main/java/vazkii/botania/common/item/lens/LensWeight.java
@@ -14,8 +14,11 @@ import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.item.EntityFallingBlock;
 import net.minecraft.entity.projectile.EntityThrowable;
+import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.RayTraceResult;
+import net.minecraft.world.World;
 import vazkii.botania.api.internal.IManaBurst;
 import vazkii.botania.common.core.handler.ConfigHandler;
 
@@ -32,7 +35,7 @@ public class LensWeight extends Lens {
 			int neededHarvestLevel = block.getHarvestLevel(state);
 			
 			if(blockBelow.isAir(entity.worldObj.getBlockState(pos.getBlockPos().down()), entity.worldObj, pos.getBlockPos().down()) && state.getBlockHardness(entity.worldObj, pos.getBlockPos()) != -1 && neededHarvestLevel <= harvestLevel && entity.worldObj.getTileEntity(pos.getBlockPos()) == null && block.canSilkHarvest(entity.worldObj, pos.getBlockPos(), entity.worldObj.getBlockState(pos.getBlockPos()), null)) {
-				EntityFallingBlock falling = new EntityFallingBlock(entity.worldObj, pos.getBlockPos().getX() + 0.5, pos.getBlockPos().getY() + 0.5, pos.getBlockPos().getZ() + 0.5, state);
+				EntityFallingBlock falling = new EntityCustomFallingBlock(entity.worldObj, pos.getBlockPos().getX() + 0.5, pos.getBlockPos().getY() + 0.5, pos.getBlockPos().getZ() + 0.5, state);
 				entity.worldObj.spawnEntityInWorld(falling);
 			}
 		}
@@ -40,4 +43,24 @@ public class LensWeight extends Lens {
 		return dead;
 	}
 
+	private static final class EntityCustomFallingBlock extends EntityFallingBlock {
+
+		public EntityCustomFallingBlock(World worldIn, double x, double y, double z, IBlockState fallingBlockState) {
+			super(worldIn, x, y, z, fallingBlockState);
+		}
+
+		@Override
+		public void onUpdate() {
+			super.onUpdate();
+			if (isDead && !worldObj.getBlockState(getPosition()).isSideSolid(worldObj, getPosition(), EnumFacing.UP)) {
+				final Block blockDrop;
+				if (Block.isEqualTo(getBlock().getBlock(), Blocks.LIT_REDSTONE_ORE)) {
+					blockDrop = Blocks.REDSTONE_ORE;
+				} else if (Block.isEqualTo(getBlock().getBlock(), Blocks.LIT_REDSTONE_LAMP)) {
+					blockDrop = Blocks.REDSTONE_LAMP;
+				} else return;
+				entityDropItem(new ItemStack(blockDrop, 1), 0);
+			}
+		}
+	}
 }


### PR DESCRIPTION
Lit Redstone Ore and Lamps hit by the weight lens will drop their items
instead of being deleted when they fall on e.g. a torch.

Couldn't find a way to do this without a new class. Using `setBlockState()`, if the block hit is a Redstone Lamp, the resulting block update just makes it light up again, and changing the type of the `EntityFallingBlock` doesn't do it either, as it deletes itself if its internal state and the one in the world don't match.
