### PR TITLE
possible fix for #311 (bubbell's fake air)

### DIFF
--- a/src/main/java/vazkii/botania/common/block/BlockFakeAir.java
+++ b/src/main/java/vazkii/botania/common/block/BlockFakeAir.java
@@ -36,8 +36,13 @@ public class BlockFakeAir extends BlockMod {
 	private static final AxisAlignedBB AABB = new AxisAlignedBB(0, 0, 0, 0, 0, 0);
 
 	public BlockFakeAir() {
-		super(Material.AIR, LibBlockNames.FAKE_AIR);
+		super(Material.PORTAL, LibBlockNames.FAKE_AIR);
 		setTickRandomly(true);
+	}
+	
+	@Override
+    public boolean isReplaceable(IBlockAccess worldIn, BlockPos pos) {
+		return true;
 	}
 
 	@Nonnull
@@ -67,8 +72,12 @@ public class BlockFakeAir extends BlockMod {
 
 	@Override
 	public void updateTick(World world, BlockPos pos, IBlockState state, Random rand) {
-		if(shouldRemove(world, pos))
-			world.setBlockState(pos, Blocks.WATER.getDefaultState());
+		if(shouldRemove(world, pos)) {
+			if(rand.nextInt(20) == 0)
+				world.setBlockState(pos, Blocks.WATER.getDefaultState());
+			else
+				world.setBlockState(pos, Blocks.AIR.getDefaultState());
+		}
 	}
 
 	@Override


### PR DESCRIPTION
#311 We can use any material that blocks water. Portal seems like a decent choice, though we have to override isReplaceable.

Previously, the mechanics of removing were thus: Upon random chunk ticks, the fake air would see if the flower was still operating. If not, it would replace itself with water. I've changed this to a 5% chance of water, else air.

Without the random chance of air, removing the flower caused a wave of water source updates. With it, the water actually flows, a bit like it does currently.

Currently, a source block pops up on a chunk tick, and only flows when a neighbor is updated (randomly or manually). This change makes it so that any water blocks that pass the 5% check start spreading immediately, but they are rare enough so that the reappearing water flows somewhat naturally.

A possible drawback is that there's no guarantee of water reappearing, so with a low number of fake air blocks...

However, the water-air boundary behaves well while the flower is active. Try repeatedly placing a torch at the edge of the bubble :smile: 
