### PR TITLE
Added ManaDiscountEvent

### DIFF
--- a/src/main/java/vazkii/botania/api/mana/ManaDiscountEvent.java
+++ b/src/main/java/vazkii/botania/api/mana/ManaDiscountEvent.java
@@ -1,0 +1,39 @@
+/**
+ * This class was created by <Flaxbeard>. It's distributed as
+ * part of the Botania Mod. Get the Source Code in github:
+ * https://github.com/Vazkii/Botania
+ * 
+ * Botania is Open Source and distributed under the
+ * Botania License: http://botaniamod.net/license.php
+ * 
+ * File Created @ [Jul 25, 2016, 9:02:12 PM (GMT)]
+ */
+package vazkii.botania.api.mana;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+public class ManaDiscountEvent extends Event {
+
+	private final EntityPlayer entityPlayer;
+	private float discount;
+
+	public ManaDiscountEvent(EntityPlayer entityPlayer, float discount) {
+		this.entityPlayer = entityPlayer;
+		this.discount = discount;
+	}
+	
+	public EntityPlayer getEntityPlayer() {
+		return entityPlayer;
+	}
+	
+	public float getDiscount() {
+		return discount;
+	}
+
+	public void setDiscount(float discount) {
+		this.discount = discount;
+	}
+}

--- a/src/main/java/vazkii/botania/api/mana/ManaItemHandler.java
+++ b/src/main/java/vazkii/botania/api/mana/ManaItemHandler.java
@@ -13,6 +13,7 @@ package vazkii.botania.api.mana;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.MinecraftForge;
 import vazkii.botania.api.BotaniaAPI;
 
 public final class ManaItemHandler {
@@ -249,6 +250,10 @@ public final class ManaItemHandler {
 			if(armor != null && armor.getItem() instanceof IManaDiscountArmor)
 				discount += ((IManaDiscountArmor) armor.getItem()).getDiscount(armor, i, player);
 		}
+		
+		ManaDiscountEvent event = new ManaDiscountEvent(player, discount);
+		MinecraftForge.EVENT_BUS.post(event);
+		discount = event.getDiscount();
 
 		return discount;
 	}


### PR DESCRIPTION
Adds a new event, ManaDiscountEvent. The event is fired when mana is used and allows other mods to apply a mana discount (or additional mana cost). The event could be used for mana-discounting baubles, held items, potion effects, and more.

The discount passed in the event is the discount after IManaDiscountArmor is taken into consideration.
