### PR TITLE
Add floral powder to ore dictionary for wildcard dye

### DIFF
--- a/src/main/java/vazkii/botania/common/item/ModItems.java
+++ b/src/main/java/vazkii/botania/common/item/ModItems.java
@@ -423,6 +423,7 @@ public final class ModItems {
 			OreDictionary.registerOre(LibOreDict.DYE[i], new ItemStack(dye, 1, i));
 			OreDictionary.registerOre(LibOreDict.RUNE[i], new ItemStack(rune, 1, i));
 		}
+		OreDictionary.registerOre(LibOreDict.DYE_WILDCARD, new ItemStack(dye, 1, OreDictionary.WILDCARD_VALUE));
 		for(int i = 0; i < 7; i++)
 			OreDictionary.registerOre(LibOreDict.QUARTZ[i], new ItemStack(quartz, 1, i));
 

--- a/src/main/java/vazkii/botania/common/lib/LibOreDict.java
+++ b/src/main/java/vazkii/botania/common/lib/LibOreDict.java
@@ -49,6 +49,8 @@ public final class LibOreDict {
 	public static final String PRISMARINE_BLOCK = "blockPrismarine";
 	public static final String BLAZE_BLOCK = "blockBlaze";
 
+	public static final String DYE_WILDCARD = "dye";
+
 	public static final String[] FLOWER = new String[] {
 		"mysticFlowerWhite", "mysticFlowerOrange", "mysticFlowerMagenta", "mysticFlowerLightBlue",
 		"mysticFlowerYellow", "mysticFlowerLime", "mysticFlowerPink", "mysticFlowerGray",


### PR DESCRIPTION
This allows mods that have recipes containing the "dye" ore dictionary name to accept floral powders.
